### PR TITLE
モーダルを2回目以降に開いたとき、前回選択したデバイスが選択されている状態にする

### DIFF
--- a/src/SelectMediaDevicesModal/index.tsx
+++ b/src/SelectMediaDevicesModal/index.tsx
@@ -96,6 +96,7 @@ const SelectMediaDevicesModal = ({
                         <DeviceList
                             label={audioInputDeviceLabel}
                             devices={audioInputDevices}
+                            selectedDevice={audioInputDevice}
                             onChange={handleChangeAudioInputDevice}
                         ></DeviceList>
                     )}
@@ -103,6 +104,7 @@ const SelectMediaDevicesModal = ({
                         <DeviceList
                             label={audioOutputDeviceLabel}
                             devices={audioOutputDevices}
+                            selectedDevice={audioOutputDevice}
                             onChange={handleChangeAudioOutputDevice}
                         ></DeviceList>
                     )}
@@ -110,6 +112,7 @@ const SelectMediaDevicesModal = ({
                         <DeviceList
                             label={videoInputDeviceLabel}
                             devices={videoInputDevices}
+                            selectedDevice={videoInputDevice}
                             onChange={handleChangeVideoInputDevice}
                         ></DeviceList>
                     )}

--- a/src/SelectMediaDevicesPreviewModal/index.tsx
+++ b/src/SelectMediaDevicesPreviewModal/index.tsx
@@ -129,6 +129,7 @@ const SelectMediaDevicesPreviewModal = ({
                             <DeviceList
                                 label={audioInputDeviceLabel}
                                 devices={audioInputDevices}
+                                selectedDevice={audioInputDevice}
                                 onChange={handleChangeAudioInputDevice}
                             ></DeviceList>
                         )}
@@ -136,6 +137,7 @@ const SelectMediaDevicesPreviewModal = ({
                             <DeviceList
                                 label={audioOutputDeviceLabel}
                                 devices={audioOutputDevices}
+                                selectedDevice={audioOutputDevice}
                                 onChange={handleChangeAudioOutputDevice}
                             ></DeviceList>
                         )}
@@ -143,6 +145,7 @@ const SelectMediaDevicesPreviewModal = ({
                             <DeviceList
                                 label={videoInputDeviceLabel}
                                 devices={videoInputDevices}
+                                selectedDevice={videoInputDevice}
                                 onChange={handleChangeVideoInputDevice}
                             ></DeviceList>
                         )}

--- a/src/SelectMediaDevicesRecordingModal/index.tsx
+++ b/src/SelectMediaDevicesRecordingModal/index.tsx
@@ -193,6 +193,7 @@ const SelectMediaDevicesRecordingModal = ({
                                 <DeviceList
                                     label={audioInputDeviceLabel}
                                     devices={audioInputDevices}
+                                    selectedDevice={audioInputDevice}
                                     onChange={handleChangeAudioInputDevice}
                                 ></DeviceList>
                                 <div className={s.buttons}>
@@ -210,6 +211,7 @@ const SelectMediaDevicesRecordingModal = ({
                             <DeviceList
                                 label={audioOutputDeviceLabel}
                                 devices={audioOutputDevices}
+                                selectedDevice={audioOutputDevice}
                                 onChange={handleChangeAudioOutputDevice}
                             ></DeviceList>
                         )}
@@ -217,6 +219,7 @@ const SelectMediaDevicesRecordingModal = ({
                             <DeviceList
                                 label={videoInputDeviceLabel}
                                 devices={videoInputDevices}
+                                selectedDevice={videoInputDevice}
                                 onChange={handleChangeVideoInputDevice}
                             ></DeviceList>
                         )}

--- a/src/components/deviceList/index.tsx
+++ b/src/components/deviceList/index.tsx
@@ -5,10 +5,11 @@ import s from './style.module.css';
 interface DeviceListProps {
     devices: MediaDeviceInfo[];
     label: string;
+    selectedDevice?: MediaDeviceInfo;
     onChange: (deviceId: string) => void;
 }
 
-const DeviceList = ({ devices, label, onChange }: DeviceListProps) => {
+const DeviceList = ({ devices, label, selectedDevice, onChange }: DeviceListProps) => {
     if (devices === undefined) return <></>;
 
     const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -20,7 +21,7 @@ const DeviceList = ({ devices, label, onChange }: DeviceListProps) => {
     return (
         <div className={s.deviceList}>
             <label htmlFor={selectId}>{label}</label>
-            <select className={s.select} id={selectId} onChange={handleChange}>
+            <select className={s.select} id={selectId} onChange={handleChange} defaultValue={selectedDevice?.deviceId}>
                 {devices.map((d, i) => (
                     <DeviceItem value={d.deviceId} name={d.label} key={i}></DeviceItem>
                 ))}


### PR DESCRIPTION
#27 の対応

exampleのように複数のモーダルで設定を共有したりしていると予期しない動きになりますが、そういう使い方はあまりしないと思うのでこの対応で十分かと思います