### PR TITLE
モーダルを2回目以降に開いたとき、プレビューが選択と違っている

### DIFF
--- a/src/SelectMediaDevicesPreviewModal/index.tsx
+++ b/src/SelectMediaDevicesPreviewModal/index.tsx
@@ -60,7 +60,7 @@ const SelectMediaDevicesPreviewModal = ({
     useEffect(() => {
         if (videoInputDevices.length < 1) return;
 
-        const [device] = videoInputDevices;
+        const device = videoInputDevices.find((d) => d.deviceId === videoInputDevice?.deviceId) ?? videoInputDevices[0];
         getVideoStream(device);
     }, [videoInputDevices]);
 

--- a/src/SelectMediaDevicesRecordingModal/index.tsx
+++ b/src/SelectMediaDevicesRecordingModal/index.tsx
@@ -69,7 +69,7 @@ const SelectMediaDevicesRecordingModal = ({
     useEffect(() => {
         if (videoInputDevices.length < 1) return;
 
-        const [device] = videoInputDevices;
+        const device = videoInputDevices.find((d) => d.deviceId === videoInputDevice?.deviceId) ?? videoInputDevices[0];
         getVideoStream(device);
     }, [videoInputDevices]);
 


### PR DESCRIPTION
#28 でモーダルが選択したデバイスを覚えておくようになったため、videoのプレビューが選択と違うデバイスになってしまう

1. プレビューのあるモーダル(SelectMediaDevicesPreviewModal, SelectMediaDevicesRecordingModal)を開く
2. 2番目以降のVideoInputDeviceを選択する
3. Confirmで閉じる
4. もう一度モーダルを開く

この4.の時点で選択されているのは2.で選択したデバイスだが、プレビューはリストの最初のVideoInputDeviceのものとなっていた

このPRは上記の問題を修正します