### PR TITLE
Fix a bug that changed video resolution

### DIFF
--- a/__tests__/SelectMediaDevicesPreviewModal.test.tsx
+++ b/__tests__/SelectMediaDevicesPreviewModal.test.tsx
@@ -12,7 +12,9 @@ vi.mock('../src/hooks/useGetMediaStream');
 describe('SelectMediaDevicesPreviewModal', () => {
     let videoElementPlayMock: SpyInstance<any[], Promise<void>>;
     const useGetDevicesMock = useGetDevices as jest.Mock<[MediaDeviceInfo[], () => void]>;
-    const useGetMediaStreamMock = useGetMediaStream as jest.Mock<[MediaStream, (device: MediaDeviceInfo) => void]>;
+    const useGetMediaStreamMock = useGetMediaStream as jest.Mock<
+        [MediaStream, (device: MediaDeviceInfo) => void, () => void]
+    >;
     const fakeDevices: MediaDeviceInfo[] = [
         {
             deviceId: 'fake device1 id',
@@ -54,7 +56,7 @@ describe('SelectMediaDevicesPreviewModal', () => {
         });
 
         useGetMediaStreamMock.mockImplementation(() => {
-            return [new MediaStream(), vi.fn()];
+            return [new MediaStream(), vi.fn(), vi.fn()];
         });
     });
 

--- a/__tests__/SelectMediaDevicesRecordingModal.test.tsx
+++ b/__tests__/SelectMediaDevicesRecordingModal.test.tsx
@@ -12,7 +12,9 @@ vi.mock('../src/hooks/useGetMediaStream');
 describe('SelectMediaDevicesRecordingModal', () => {
     let videoElementPlayMock: SpyInstance<any[], Promise<void>>;
     const useGetDevicesMock = useGetDevices as jest.Mock<[MediaDeviceInfo[], () => void]>;
-    const useGetMediaStreamMock = useGetMediaStream as jest.Mock<[MediaStream, (device: MediaDeviceInfo) => void]>;
+    const useGetMediaStreamMock = useGetMediaStream as jest.Mock<
+        [MediaStream, (device: MediaDeviceInfo) => void, () => void]
+    >;
     const fakeDevices: MediaDeviceInfo[] = [
         {
             deviceId: 'fake device1 id',
@@ -54,7 +56,7 @@ describe('SelectMediaDevicesRecordingModal', () => {
         });
 
         useGetMediaStreamMock.mockImplementation(() => {
-            return [new MediaStream(), vi.fn()];
+            return [new MediaStream(), vi.fn(), vi.fn()];
         });
     });
 

--- a/example/src/App.jsx
+++ b/example/src/App.jsx
@@ -4,7 +4,7 @@ import {
     SelectMediaDevicesModal,
     SelectMediaDevicesRecordingModal,
 } from 'react-select-media-devices-modal';
-import Webcam from 'react-webcam'
+import Webcam from 'react-webcam';
 
 function App() {
     const [modalOpen, setModalOpen] = useState(false);

--- a/src/SelectMediaDevicesPreviewModal/index.tsx
+++ b/src/SelectMediaDevicesPreviewModal/index.tsx
@@ -44,7 +44,7 @@ const SelectMediaDevicesPreviewModal = ({
     const [audioOutputDevice, setAudioOutputDevice] = useState<MediaDeviceInfo>();
     const [videoInputDevice, setVideoInputDevice] = useState<MediaDeviceInfo>();
 
-    const [videoStream, getVideoStream] = useGetMediaStream();
+    const [videoStream, getVideoStream, stopVideoStream] = useGetMediaStream();
     const videoPreviewRef = useRef<HTMLVideoElement>();
 
     const audioInputDevices = useMemo(() => devices.filter((d) => d.kind === 'audioinput'), [devices]);
@@ -68,6 +68,7 @@ const SelectMediaDevicesPreviewModal = ({
     }, [videoInputDevices]);
 
     const handleConfirmClick = () => {
+        stopVideoStream();
         onDeviceSelected({
             audioInput: audioInputDevice !== undefined ? audioInputDevice : audioInputDevices[0],
             audioOutput: audioOutputDevice !== undefined ? audioOutputDevice : audioOutputDevices[0],
@@ -76,6 +77,7 @@ const SelectMediaDevicesPreviewModal = ({
     };
 
     const handleCancelClick = () => {
+        stopVideoStream();
         onDeviceSelectCanceled();
     };
 
@@ -96,7 +98,7 @@ const SelectMediaDevicesPreviewModal = ({
     useEffect(() => {
         const { current } = videoPreviewRef;
 
-        if (current === undefined) return;
+        if (!current) return;
 
         if (current.srcObject !== null) {
             if (current.srcObject instanceof MediaStream) {
@@ -110,6 +112,7 @@ const SelectMediaDevicesPreviewModal = ({
     }, [videoStream]);
 
     const handleOutsideClick = () => {
+        stopVideoStream();
         onDeviceSelectCanceled();
     };
 

--- a/src/SelectMediaDevicesRecordingModal/index.tsx
+++ b/src/SelectMediaDevicesRecordingModal/index.tsx
@@ -46,7 +46,7 @@ const SelectMediaDevicesRecordingModal = ({
     const [audioOutputDevice, setAudioOutputDevice] = useState<MediaDeviceInfo>();
     const [videoInputDevice, setVideoInputDevice] = useState<MediaDeviceInfo>();
 
-    const [videoStream, getVideoStream] = useGetMediaStream();
+    const [videoStream, getVideoStream, stopVideoStream] = useGetMediaStream();
     const videoPreviewRef = useRef<HTMLVideoElement>();
     const audioPreviewRef = useRef<
         HTMLAudioElement & {
@@ -87,6 +87,7 @@ const SelectMediaDevicesRecordingModal = ({
         }
         audioPreviewRef.current.src = '';
         audioPreviewRef.current.pause();
+        stopVideoStream();
     };
 
     const handleConfirmClick = () => {

--- a/src/hooks/useGetMediaStream.ts
+++ b/src/hooks/useGetMediaStream.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-export const useGetMediaStream = (): [MediaStream, (device: MediaDeviceInfo) => void] => {
+export const useGetMediaStream = (): [MediaStream, (device: MediaDeviceInfo) => void, () => void] => {
     const [mediaStream, setMediaStream] = useState<MediaStream>();
 
     useEffect(() => {
@@ -23,5 +23,11 @@ export const useGetMediaStream = (): [MediaStream, (device: MediaDeviceInfo) => 
         })();
     };
 
-    return [mediaStream, getMediaStream];
+    const stopMediaStream = () => {
+        if (mediaStream === undefined) return;
+        mediaStream.getTracks().forEach((t) => t.stop());
+        setMediaStream(undefined);
+    };
+
+    return [mediaStream, getMediaStream, stopMediaStream];
 };


### PR DESCRIPTION
fix #37 

- モーダルを閉じる際に、MediaStreamの停止処理を実行して、アプリ側表示の解像度が勝手に変わってしまう問題を回避する
- 解像度とフレームレートが元のままとなることを確認